### PR TITLE
Elimina el panell sobre les eleccions a rector

### DIFF
--- a/public/activitat.html
+++ b/public/activitat.html
@@ -75,6 +75,15 @@ require('skeleton_header.php');
     </div>
 	<h3>Altres accions</h3>
 
+    <h4>Novembre 2017</h4>
+    <p>
+        Durant les eleccions a Rector, vam preparar un document amb les
+        <a href="inquietuds_pas.html" title="Inquietuds del PAS recollides durant les eleccions a Rector el 2017">inquietuds del PAS</a>
+        que vam presentar als candidats a
+        <a href="https://enricfossas.cat/">Enric Fossas</a> i
+        <a href="http://www.francesctorres.cat/">Francesc Torres</a>.
+    </p>
+
 	<h4>Novembre 2013</h4>
 	<p>Durant les eleccions a Rector, vam enviar un <a href="doc/questionari_rectorables.pdf" title="Qüestionari per als candidats a rector">qüestionari als candidats</a>
 	   i vam publicar les seves respostes:</p>

--- a/public/index.html
+++ b/public/index.html
@@ -15,20 +15,6 @@
 			<p class="lead">Entre nosaltres trobareu <a href="membres_claustre.html">representants al Claustre</a>, al Consell
 	               de Govern i al Consell Social de la UPC. Volem fer sentir la vostra veu!</p>
 
-			<div class="col-md-12" onclick="document.location='inquietuds-pas.html'">
-				<div class="panel panel-primary">
-					<div class="panel-heading lead">Eleccions a Rector UPC</div>
-					<div class="panel-body">
-						<p>Estem preparant un <a href="inquietuds_pas.html"><b>document amb les inquietuds del PAS</b></a> 
-						que ens heu fet arribar fins ara. La nostra intenció és enviar presentar aquest recull d'inquietuds als 
-						candidats a Rector <a href="https://enricfossas.cat/">Enric Fossas</a> i 
-						<a href="http://www.francesctorres.cat/">Francesc Torres</a>.</p>
-
-						<p class="lead text-center"><a href="inquietuds_pas.html">Fes-nos arribar els teus comentaris</a></p>
-					</div>
-				</div>
-			</div>
-
 			<div id="capsetes">
 			
 			<div class="col-md-4" onclick="document.location='carta.html'" style="cursor:pointer">


### PR DESCRIPTION
Ja han passat uns anys des de les darreres eleccions i ara no té
gaire sentit parlar sobre les inquietuds del PAS que vam recollir
durant la campanya. En canvi he afegit una nova entrada a la pàgina
d'activitats.